### PR TITLE
chore(deployment): update dev containers

### DIFF
--- a/packages/backend/deployments/local/Containerfile.development
+++ b/packages/backend/deployments/local/Containerfile.development
@@ -5,6 +5,7 @@ USER root
 
 # Install development tools
 RUN dnf install -y git postgresql && \
+    curl -sSf https://atlasgo.sh | sh && \
     dnf clean all
 
 RUN mkdir -p /opt/app-root/src && \
@@ -36,9 +37,6 @@ COPY --chown=1001:0 . .
 
 RUN chmod +x ./scripts/deploy/dev.sh
 
-EXPOSE 3000
-
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl --fail --silent http://localhost:3000/health || exit 1
+EXPOSE 8080
 
 ENTRYPOINT ["./scripts/deploy/dev.sh"]

--- a/packages/backend/deployments/local/Containerfile.init
+++ b/packages/backend/deployments/local/Containerfile.init
@@ -3,7 +3,7 @@ FROM registry.redhat.io/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3
 
 USER root
 
-RUN microdnf install -y nc && \
+RUN microdnf install -y postgresql && \
     curl -sSf https://atlasgo.sh | sh && \
     microdnf clean all && \
     rm -rf /var/cache/yum
@@ -15,9 +15,9 @@ COPY --chown=1001:1001 atlas.hcl .
 COPY --chown=1001:1001 migrations/ ./migrations/
 
 # Entrypoint script
-COPY --chown=1001:1001 scripts/deploy/init.sh .
-RUN chmod +x init.sh
+COPY --chown=1001:1001 scripts/deploy/init.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
 
 USER 1001
 
-ENTRYPOINT [ "./init.sh" ]
+ENTRYPOINT [ "./entrypoint.sh" ]


### PR DESCRIPTION
Updates dev containers to use port 8080 (same as Prod).
Relies on https://github.com/konflux-ci/kite/pull/2
