### PR TITLE
chore(db): update migration setup

### DIFF
--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -1,0 +1,18 @@
+.PHONY: migrate seed status migration
+
+# Apply pending migrations
+migrate:
+	atlas migrate apply --env local
+
+# Seed database
+seed:
+	go run -mod=mod cmd/seed/main.go
+
+# Get status of DB migrations (applied, pending)
+status:
+	atlas migrate status --env local
+
+# Generate a new migration (requires NAME variable)
+# Usage: make migraiton NAME="add_some_column"
+migration:
+	atlas migrate diff "$(NAME)" --env local

--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -4,7 +4,7 @@
 migrate:
 	atlas migrate apply --env local
 
-# Seed database
+# Seed database (non-prod DBs)
 seed:
 	go run -mod=mod cmd/seed/main.go
 
@@ -13,6 +13,6 @@ status:
 	atlas migrate status --env local
 
 # Generate a new migration (requires NAME variable)
-# Usage: make migraiton NAME="add_some_column"
+# Usage: make migration NAME="add_some_column"
 migration:
 	atlas migrate diff "$(NAME)" --env local

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -59,5 +59,26 @@ This is used by the service to talk to the cluster, allowing it to perform actio
 
 ### 5. Access the Application
 
-- API: http://localhost:3000/health
+- API: http://localhost:8080/health
 
+## Migrations
+
+First, you'll need to get into the container by running:
+
+```bash
+<docker|podman> compose -f compose.yaml exec app bash
+```
+
+Then all migration operations can be done using the `make` (see `Makefile`):
+
+```bash
+# Alter schema
+# Generate new migration with changes
+make migration NAME="add_some_column"
+
+# Apply pending migrations
+make migrate
+
+# Get status of DB migrations
+make status
+```

--- a/packages/backend/cmd/seed/main.go
+++ b/packages/backend/cmd/seed/main.go
@@ -15,7 +15,7 @@ func main() {
 	logger.SetLevel(logrus.InfoLevel)
 
 	// Check which environment we're in
-	env := os.Getenv("PROJECT_ENV")
+	env := os.Getenv("KITE_PROJECT_ENV")
 	if env == "production" {
 		logger.Fatal("Seeder can only be used in the development environment")
 	}

--- a/packages/backend/deployments/local/Containerfile.development
+++ b/packages/backend/deployments/local/Containerfile.development
@@ -5,6 +5,7 @@ USER root
 
 # Install development tools
 RUN dnf install -y git postgresql && \
+    curl -sSf https://atlasgo.sh | sh && \
     dnf clean all
 
 RUN mkdir -p /opt/app-root/src && \
@@ -36,9 +37,6 @@ COPY --chown=1001:0 . .
 
 RUN chmod +x ./scripts/deploy/dev.sh
 
-EXPOSE 3000
-
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl --fail --silent http://localhost:3000/health || exit 1
+EXPOSE 8080
 
 ENTRYPOINT ["./scripts/deploy/dev.sh"]

--- a/packages/backend/deployments/local/Containerfile.development
+++ b/packages/backend/deployments/local/Containerfile.development
@@ -5,11 +5,17 @@ USER root
 
 # Install development tools
 RUN dnf install -y git postgresql && \
-    curl -sSf https://atlasgo.sh | sh && \
     dnf clean all
 
+# Get Atlas, verify, install
+RUN curl -L -o atlas https://release.ariga.io/atlas/atlas-linux-amd64-latest && \
+    curl -L -o atlas.sha256 https://release.ariga.io/atlas/atlas-linux-amd64-latest.sha256 && \
+    echo "$(cat atlas.sha256) atlas" | sha256sum -c - && \
+    chmod +x atlas && \
+    mv atlas /usr/local/bin
+
 RUN mkdir -p /opt/app-root/src && \
-    chown -R 1001:0 /opt/app-root
+chown -R 1001:0 /opt/app-root
 
 # Switch to user 1001 for Go operations
 USER 1001
@@ -26,7 +32,7 @@ RUN mkdir -p $GOCACHE $GOPATH/bin && \
     chmod -R 755 $GOCACHE $GOPATH
 
 # Install Air for hot reloading
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.61.7
 
 # Copy go mod files first for better caching
 COPY --chown=1001:0 go.mod go.sum ./

--- a/packages/backend/deployments/local/Containerfile.init
+++ b/packages/backend/deployments/local/Containerfile.init
@@ -3,7 +3,7 @@ FROM registry.redhat.io/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3
 
 USER root
 
-RUN microdnf install -y nc && \
+RUN microdnf install -y postgresql && \
     curl -sSf https://atlasgo.sh | sh && \
     microdnf clean all && \
     rm -rf /var/cache/yum
@@ -15,9 +15,9 @@ COPY --chown=1001:1001 atlas.hcl .
 COPY --chown=1001:1001 migrations/ ./migrations/
 
 # Entrypoint script
-COPY --chown=1001:1001 scripts/deploy/init.sh .
-RUN chmod +x init.sh
+COPY --chown=1001:1001 scripts/deploy/init.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
 
 USER 1001
 
-ENTRYPOINT [ "./init.sh" ]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/packages/backend/deployments/local/Containerfile.init
+++ b/packages/backend/deployments/local/Containerfile.init
@@ -4,9 +4,15 @@ FROM registry.redhat.io/ubi9/ubi-minimal@sha256:92b1d5747a93608b6adb64dfd54515c3
 USER root
 
 RUN microdnf install -y postgresql && \
-    curl -sSf https://atlasgo.sh | sh && \
     microdnf clean all && \
     rm -rf /var/cache/yum
+
+# Get Atlas, verify, install
+RUN curl -L -o atlas https://release.ariga.io/atlas/atlas-linux-amd64-latest && \
+    curl -L -o atlas.sha256 https://release.ariga.io/atlas/atlas-linux-amd64-latest.sha256 && \
+    echo "$(cat atlas.sha256) atlas" | sha256sum -c - && \
+    chmod +x atlas && \
+    mv atlas /usr/local/bin
 
 WORKDIR /opt/app-root/src
 

--- a/packages/backend/deployments/openshift/Containerfile.init
+++ b/packages/backend/deployments/openshift/Containerfile.init
@@ -19,10 +19,15 @@ USER root
 WORKDIR /opt/app-root/src
 
 RUN microdnf install -y postgresql && \
-
-    curl -sSf https://atlasgo.sh | sh && \
     microdnf clean all && \
     rm -rf /var/cache/yum
+
+# Get Atlas, verify, install
+RUN curl -L -o atlas https://release.ariga.io/atlas/atlas-linux-amd64-latest && \
+    curl -L -o atlas.sha256 https://release.ariga.io/atlas/atlas-linux-amd64-latest.sha256 && \
+    echo "$(cat atlas.sha256) atlas" | sha256sum -c - && \
+    chmod +x atlas && \
+    mv atlas /usr/local/bin
 
 # Atlas config, migrations and entrypoint
 COPY atlas.hcl .

--- a/packages/backend/deployments/openshift/Containerfile.production
+++ b/packages/backend/deployments/openshift/Containerfile.production
@@ -72,7 +72,7 @@ COPY scripts/deploy/prod.sh entrypoint.sh
 RUN chmod -R g=u . && \
     chmod +x entrypoint.sh
 
-ENV PROJECT_ENV=production
+ENV KITE_PROJECT_ENV=production
 
 # Set non-root user
 USER 1001

--- a/packages/backend/internal/config/database.go
+++ b/packages/backend/internal/config/database.go
@@ -43,7 +43,7 @@ func InitDatabase() (*gorm.DB, error) {
 
 	// Configure logger based on environment
 	var gormLogger logger.Interface
-	if os.Getenv("PROJECT_ENV") == "development" {
+	if os.Getenv("KITE_PROJECT_ENV") == "development" {
 		gormLogger = logger.Default.LogMode(logger.Info)
 	} else {
 		gormLogger = logger.Default.LogMode(logger.Error)


### PR DESCRIPTION
These changes should make it easier for devs to work with the database tooling.
The commands will be run from within the dev container, see README instructions.

**Changes**:
- updates the config and doc section related to DB migrations
- update dev containers with DB libraries and tooling
- adds Makefile for DB commands
- update ENV vars so they're prefixed with `KITE_`
- update dev container to use port 8080, like prod.