### PR TITLE
Update README, point to new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Kite :kite:
 
+# STOP :stop_sign:
+
+There is a new repository for this project: https://github.com/Issues-Dashboard/kite
+
 ![Go CI Checks](https://github.com/konflux-ci/kite/actions/workflows/go-ci-checks.yaml/badge.svg)
 
 :construction: **Proof of Concept** - APIs and core functionality may change. See [Status](#status) below.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Kite :kite:
-
 # STOP :stop_sign:
 
 There is a new repository for this project: https://github.com/Issues-Dashboard/kite
+
+---
 
 ![Go CI Checks](https://github.com/konflux-ci/kite/actions/workflows/go-ci-checks.yaml/badge.svg)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Konflux Issue Tracking Engine (Kite) :kite:
+# Kluster Issue Tracking Engine (Kite) :kite:
 
 ![Go CI Checks](https://github.com/konflux-ci/kite/actions/workflows/go-ci-checks.yaml/badge.svg)
 
@@ -8,7 +8,7 @@
 
 ## What is Kite?
 
-Kite is a set of components that **detect, create and track issues** that can disrupt applications in Konflux.
+Kite is a set of components that **detect, create and track issues** that can disrupt applications in your cluster.
 
 Typical issues include:
 
@@ -35,7 +35,7 @@ Typical issues include:
 - **REST API**: Integrate with external tools (such as the Issues Dashboard **WIP**).
 - **Extensible Operator**: Add custom controllers to watch cluster resources and open/resolve issues in Kite.
 
-All these components work together to create and track issues that may disrupt your ability to build and deploy applications in Konflux.
+All these components work together to create and track issues that may disrupt your ability to build and deploy applications in your cluster.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kluster Issue Tracking Engine (Kite) :kite:
+# Kite :kite:
 
 ![Go CI Checks](https://github.com/konflux-ci/kite/actions/workflows/go-ci-checks.yaml/badge.svg)
 


### PR DESCRIPTION
During the ADR review process for this service two things were requested:
- That this project gets moved to another repository in another org: https://github.com/Issues-Dashboard/kite
- That the name be changed so it is not officially associated with Konflux.